### PR TITLE
Fix google cloud dependency issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,13 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+              <groupId>com.google.cloud</groupId>
+              <artifactId>libraries-bom</artifactId>
+              <version>26.1.2</version>
+              <type>pom</type>
+              <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>io.github.jhipster</groupId>
                 <artifactId>jhipster-dependencies</artifactId>
                 <version>${jhipster-dependencies.version}</version>
@@ -106,13 +113,6 @@
                 <scope>import</scope>
             </dependency>
             <!-- jhipster-needle-maven-add-dependency-management -->
-            <dependency>
-                 <groupId>com.google.cloud</groupId>
-                 <artifactId>libraries-bom</artifactId>
-                <version>26.1.2</version>
-                 <type>pom</type>
-                 <scope>import</scope>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -386,32 +386,7 @@
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-recaptchaenterprise</artifactId>
-            <version>3.0.11</version>
         </dependency>
-        <dependency>
-            <groupId>com.google.cloud</groupId>
-            <artifactId>google-cloud-storage</artifactId>
-            </dependency>
-        <dependency>
-            <groupId>com.google.api</groupId>
-            <artifactId>gax</artifactId>
-            <version>2.19.2</version> 
-        </dependency>
-        <dependency>
-	        <groupId>com.google.auth</groupId>
-	        <artifactId>google-auth-library-oauth2-http</artifactId>
-	        <version>1.7.0</version>
-        </dependency>
-         <dependency>
-	        <groupId>com.google.auth</groupId>
-	        <artifactId>google-auth-library-credentials</artifactId>
-	        <version>1.7.0</version>
-        </dependency>
-        <!-- <dependency>
-            <groupId>com.google.api</groupId>
-            <artifactId>gax</artifactId>
-            <version>1.67</version>
-        </dependency> -->
     </dependencies>
 
     <build>

--- a/src/main/java/org/mskcc/cbio/oncokb/web/rest/CreateAssessment.java
+++ b/src/main/java/org/mskcc/cbio/oncokb/web/rest/CreateAssessment.java
@@ -25,7 +25,7 @@ public class CreateAssessment {
    * is the same for
    * both 'score' and 'checkbox' type recaptcha site keys.
    *
-   * @param token           : The token obtained from the client on passing the
+   * @param recaptchaToken           : The token obtained from the client on passing the
    *                        recaptchaSiteKey.
    * @param recaptchaAction : Action name corresponding to the token.
    * @return
@@ -33,7 +33,7 @@ public class CreateAssessment {
    */
   public static ResponseEntity<String> createAssessment(HttpServletRequest request, @RequestParam String recaptchaToken, String recaptchaAction)
       throws IOException, ValidationException {
- 
+
     String projectID = "symbolic-nation-320615";
     String recaptchaSiteKey = "6LdTXvMhAAAAAN7kj4MRKX0fl_gXUv_IQbxARe6W";
 


### PR DESCRIPTION
When using multiple import in dependencyManagement, the first declaration takes effect if it's not declared in dependencyManagement. I think jhipster uses an older version of the Guava.
Please see https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#importing-dependencies for example.